### PR TITLE
fixed typos in slide decks 4 - 6

### DIFF
--- a/04-HTTP.html
+++ b/04-HTTP.html
@@ -112,7 +112,7 @@
       </section>
       <section>
         <ul>
-          <li>RFC: The standard for HTPP: <a href="http://tools.ietf.org/html/rfc2616">http://tools.ietf.org/html/rfc2616</a></li>
+          <li>RFC: The standard for HTTP: <a href="http://tools.ietf.org/html/rfc2616">http://tools.ietf.org/html/rfc2616</a></li>
           <li>RFC: Request For Comments
             <ul>
               <li>Hypertext Transfer Protocol &mdash; HTTP/1.1</li>
@@ -155,7 +155,7 @@
           </li>
           <li class="rare">PATCH – Modify the entity at that URI
           </li>
-          <li class="rare">OPTIONS – What options a resource can accomidate
+          <li class="rare">OPTIONS – What options a resource can accommodate
           </li>
           <li class="rare">TRACE – Debugging / Echo Request
           </li>
@@ -5058,7 +5058,7 @@ name=Hazel&occupation=Slide+maker</code></pre>
               <li>Multipurpose Internet Mail Extensions</li>
             </ul>
           </li>
-          <li>Mostly used to puload files as binary, but it can be used for any form</li>
+          <li>Mostly used to upload files as binary, but it can be used for any form</li>
           <li>Sends the content-size first and then asks the server if that's okay
             <ul>
               <li>Server responds <var>HTTP/1.1 100 Continue</var> if it can handle that <em>size</em> of data</li>
@@ -5083,7 +5083,7 @@ Expect: 100-continue
 Content-Type: multipart/form-data; boundary=----------------------------9edfbc1fb1b0</code></pre>
         <ul>
           <li>The boundary lets the server tell when one part of the form ends and another begins.</li>
-          <li>The random number should be chosen so that it won't show up in conentent.</li>
+          <li>The random number should be chosen so that it won't show up in the contents.</li>
         </ul>
       </section>
       <section>
@@ -5130,7 +5130,7 @@ Content-Type: text/html; charset=UTF-8
               <li>Compress headers for less bandwidth</li>
             </ul>
           </li>
-          <li>Pipelining: request requrest request ... response response response</li>
+          <li>Pipelining: request request request ... response response response</li>
           <li>Push: psychic servers look into the future and sends clients content before they even request it 🔮</li>
           <li>Multiplexing</li>
         </ul>

--- a/05-More-HTTP.html
+++ b/05-More-HTTP.html
@@ -195,7 +195,7 @@ Accept: */*
 Content-type: application/json
 Content-Length: 14
 
-</code></pre>
+{"name":"one"}</code></pre>
         <p>Server response:</p>
         <pre><code>HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -211,7 +211,7 @@ User-Agent: curl/7.29.0
 Host: cmput301.softwareprocess.es:8080
 Accept: application/json
 
-{"name":"one"}</code></pre>
+</code></pre>
         <p>Server response:</p>
         <pre><code>HTTP/1.1 200 OK
 Content-Type: application/json; charset=UTF-8
@@ -583,7 +583,7 @@ Content-Length: 60
               <li> Maybe it could answer your request but an administrator disabled that ability.</li>
             </ul>
           </li>
-          <li><var>HTTP/1.1 404 Unauthorized</var>
+          <li><var>HTTP/1.1 404 Not Found</var>
             <ul>
               <li>You've got the wrong resource or path. Can't find what you're looking for. Droids? What droids?</li>
             </ul>
@@ -693,7 +693,7 @@ Content-Length: 60
           </li>
           <li><var>HTTP/1.1 422 Unprocessable Entity</var>
             <ul>
-              <li>Indicates that the server understood the Content-Type and the syntax of the entity (request body) is correc but that it was unable to process it.</li>
+              <li>Indicates that the server understood the Content-Type and the syntax of the entity (request body) is correct but that it was unable to process it.</li>
             </ul>
           </li>
           <li><var>HTTP/1.1 426 Upgrade Required</var>
@@ -1320,7 +1320,7 @@ Content-Length: 60
           </li>
           <li><var>Trailer: Expires</var>
             <ul>
-              <li>Tells the client there will be additional headers after the conetnet is sent</li>
+              <li>Tells the client there will be additional headers after the content is sent</li>
               <li>HTTP/1.1 requires <var>Transfer-Encoding: Chunked</var> for this to work</li>
               <li>HTTP/2 doesn't work in all browsers</li>
             </ul>

--- a/06-HTML.html
+++ b/06-HTML.html
@@ -76,7 +76,7 @@
       </section>
       <section>
         <ul>
-          <li>Example compatibility talbe from MDN:</li>
+          <li>Example compatibility table from MDN:</li>
         </ul>
         <img class="stretch noborder" src="images/mdn-compatibility-table.png">
         <ul style="font-size: 80%">
@@ -556,7 +556,7 @@ Sheet properties.
           <script type="text/template">
             ## Cascading Style Sheets
 
-CSS can applied on a per tag level, but can also be applied globally.
+CSS can be applied on a per tag level, but can also be applied globally.
 
 
 ````
@@ -1156,15 +1156,6 @@ Display flex also lays out other objects too.
         <p> The HTML Form elements let us accept input from browsers in a
           structured way and form HTTP GETs and POSTs.</p>
         <p> In the lab you should have covered some of this.</p>
-      </section>
-      <!-- ######################## END HTML SLIDE ########################## -->
-
-      <!-- ######################## START HTML SLIDE ########################## -->
-      <section>
-        <h2>HTML for User Interfaces</h2>
-        <p> The HTML Form elements let us accept input from browsers in a
-          structured way and form HTTP GETs and POSTs.</p>
-
       </section>
       <!-- ######################## END HTML SLIDE ########################## -->
 

--- a/07-JS.html
+++ b/07-JS.html
@@ -616,7 +616,7 @@ for (let property in hazel) {
       <section>
         <h4><var>Object.create(prototype)</var></h4>
         <ul>
-          <li>Awkward and arely used</li>
+          <li>Awkward and rarely used</li>
         </ul>
         <pre><code class="javascript">
            // classes start with a capital letter by convention


### PR DESCRIPTION
- fixed typos.. 
- moved json body from the get request to the put request in the elasticsearch example in slide deck 5.
- removed a duplicated slide in slide deck 6.